### PR TITLE
[FEAT] 유저 프로필 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 
-import Search from '@/components/Search'
+import Header from '@/components/Header'
 
 import './globals.css'
 
@@ -20,8 +20,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <main className="flex min-h-screen flex-col items-center pt-12 gap-5">
-          <Search />
+        <main className="flex min-h-screen flex-col items-center gap-5">
+          <Header />
           <div className="flex justify-start">{children}</div>
         </main>
       </body>

--- a/src/app/user/[userid]/page.tsx
+++ b/src/app/user/[userid]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page({ params }: { params: { userid: string } }) {
+  return <div>User: {params.userid}</div>
+}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,0 +1,14 @@
+import Search from '../Search'
+import Profile from '../User/Profile'
+
+const Header = () => {
+  return (
+    <div className="top-0 sticky py-5 px-14 w-full flex justify-around items-center border-b-[1px]">
+      <div></div>
+      <Search />
+      <Profile />
+    </div>
+  )
+}
+
+export default Header

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -8,7 +8,7 @@ const Search = () => {
   const [isLoading, setIsLoading] = useState(false)
   return (
     <div
-      className={`flex items-center focus-within:border-orange-400 border-[2px] rounded-full p-[8px] min-w-[360px] h-[50px] ${isLoading ? 'border-dotted' : 'border-solid'}`}
+      className={`flex items-center focus-within:border-orange-400 border-[2px] rounded-full p-[8px] min-w-[360px] max-w-[500px] h-[50px] ${isLoading ? 'border-dotted' : 'border-solid'}`}
     >
       <SearchInput setIsLoading={setIsLoading} />
     </div>

--- a/src/components/User/Profile.tsx
+++ b/src/components/User/Profile.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useAtom } from 'jotai'
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+
+import { userAtom } from '@/stores/userAtom'
+
+interface ProfileProps {
+  profileImage?: string
+}
+
+const Profile = ({ profileImage }: ProfileProps) => {
+  const router = useRouter()
+  const user = useAtom(userAtom)
+
+  const handleProfileClick = () => {
+    if (user[0]?.user.uid === undefined) {
+      router.push('/signin')
+    } else {
+      router.push(`/user/${user[0]?.user.uid}`)
+    }
+  }
+
+  return (
+    <div onClick={handleProfileClick} className="cursor-pointer">
+      {profileImage ? (
+        <Image src={profileImage} alt="album image" width={32} height={32} />
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+        >
+          <path d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm7.753 18.305c-.261-.586-.789-.991-1.871-1.241-2.293-.529-4.428-.993-3.393-2.945 3.145-5.942.833-9.119-2.489-9.119-3.388 0-5.644 3.299-2.489 9.119 1.066 1.964-1.148 2.427-3.393 2.945-1.084.25-1.608.658-1.867 1.246-1.405-1.723-2.251-3.919-2.251-6.31 0-5.514 4.486-10 10-10s10 4.486 10 10c0 2.389-.845 4.583-2.247 6.305z" />
+        </svg>
+      )}
+    </div>
+  )
+}
+
+export default Profile

--- a/src/components/User/SignIn.tsx
+++ b/src/components/User/SignIn.tsx
@@ -2,11 +2,18 @@
 
 import { useState } from 'react'
 
+import { useSetAtom } from 'jotai'
+import { useRouter } from 'next/navigation'
+
 import { authSignIn } from '@/firebase'
+import { userAtom } from '@/stores/userAtom'
+import { UserRoot } from '@/types/user'
 
 const SignIn = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const setUserAtom = useSetAtom(userAtom)
+  const router = useRouter()
 
   const handleChangeEmail = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value)
@@ -18,6 +25,13 @@ const SignIn = () => {
 
   const handleSignIn = () => {
     authSignIn({ email, password })
+      .then((user) => {
+        setUserAtom(user as unknown as UserRoot)
+        router.push('/')
+      })
+      .catch((error) => {
+        console.log(error)
+      })
   }
 
   return (

--- a/src/components/User/SignUp.tsx
+++ b/src/components/User/SignUp.tsx
@@ -2,11 +2,18 @@
 
 import { useState } from 'react'
 
+import { useSetAtom } from 'jotai'
+import { useRouter } from 'next/navigation'
+
 import { authSignUp } from '@/firebase'
+import { userAtom } from '@/stores/userAtom'
+import { UserRoot } from '@/types/user'
 
 const SignUp = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const router = useRouter()
+  const setUserAtom = useSetAtom(userAtom)
 
   const handleChangeEmail = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value)
@@ -16,8 +23,15 @@ const SignUp = () => {
     setPassword(event.target.value)
   }
 
-  const handleSignIn = () => {
+  const handleSignUp = () => {
     authSignUp({ email, password })
+      .then((user) => {
+        setUserAtom(user as unknown as UserRoot)
+        router.push('/')
+      })
+      .catch((error) => {
+        console.log(error)
+      })
   }
 
   return (
@@ -49,7 +63,7 @@ const SignUp = () => {
       </div>
       <div className="flex pt-[30px]">
         <button
-          onClick={handleSignIn}
+          onClick={handleSignUp}
           aria-label="SignIn"
           className="bg-orange-500 w-full h-[40px] rounded"
         >

--- a/src/firebase/authSignIn.ts
+++ b/src/firebase/authSignIn.ts
@@ -3,19 +3,15 @@ import { getAuth, signInWithEmailAndPassword } from 'firebase/auth'
 import { app } from '@/firebase'
 import { UserAuth } from '@/types/user'
 
-const authSignIn = ({ email, password }: UserAuth) => {
+const authSignIn = async ({ email, password }: UserAuth) => {
   const auth = getAuth(app)
 
-  signInWithEmailAndPassword(auth, email, password)
-    .then((userCredential) => {
-      const user = userCredential.user
-      console.log(user)
-    })
-    .catch((error) => {
-      const errorCode = error.code
-      const errorMessage = error.message
-      throw new Error(`[${errorCode}] ${errorMessage}`)
-    })
+  try {
+    const user = await signInWithEmailAndPassword(auth, email, password)
+    return user
+  } catch (error) {
+    throw new Error('[authSignIn] Error')
+  }
 }
 
 export default authSignIn

--- a/src/firebase/authSignUp.ts
+++ b/src/firebase/authSignUp.ts
@@ -3,19 +3,15 @@ import { createUserWithEmailAndPassword, getAuth } from 'firebase/auth'
 import { app } from '@/firebase'
 import { UserAuth } from '@/types/user'
 
-const authSignUp = ({ email, password }: UserAuth) => {
+const authSignUp = async ({ email, password }: UserAuth) => {
   const auth = getAuth(app)
 
-  createUserWithEmailAndPassword(auth, email, password)
-    .then((userCredential) => {
-      const user = userCredential.user
-      console.log(user)
-    })
-    .catch((error) => {
-      const errorCode = error.code
-      const errorMessage = error.message
-      throw new Error(`[${errorCode}] ${errorMessage}`)
-    })
+  try {
+    const user = await createUserWithEmailAndPassword(auth, email, password)
+    return user
+  } catch (error) {
+    throw new Error('[authSignUp] Error')
+  }
 }
 
 export default authSignUp

--- a/src/stores/userAtom.ts
+++ b/src/stores/userAtom.ts
@@ -1,0 +1,5 @@
+import { atom } from 'jotai'
+
+import { UserRoot } from '@/types/user'
+
+export const userAtom = atom<UserRoot | null>(null)

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,50 @@
-export interface UserAuth {
+export type UserAuth = {
   email: string
   password: string
+}
+
+export interface UserRoot {
+  user: User
+  providerId: any
+  _tokenResponse: TokenResponse
+  operationType: string
+}
+
+export interface User {
+  uid: string
+  email: string
+  emailVerified: boolean
+  isAnonymous: boolean
+  providerData: ProviderDaum[]
+  stsTokenManager: StsTokenManager
+  createdAt: string
+  lastLoginAt: string
+  apiKey: string
+  appName: string
+}
+
+export interface ProviderDaum {
+  providerId: string
+  uid: string
+  displayName: any
+  email: string
+  phoneNumber: any
+  photoURL: any
+}
+
+export interface StsTokenManager {
+  refreshToken: string
+  accessToken: string
+  expirationTime: number
+}
+
+export interface TokenResponse {
+  kind: string
+  localId: string
+  email: string
+  displayName: string
+  idToken: string
+  registered: boolean
+  refreshToken: string
+  expiresIn: string
 }


### PR DESCRIPTION
### how?
root layout에 header 컴포넌트 제작
기존 root layout에 Search 컴포넌트를 header의 자식 컴포넌트로 이동
header 자식 컴포넌트에 유저 프로필을 보여줄 Profile 컴포넌트 제작
유저 정보 atom으로 저장
### what?
[feat: Header 컴포넌트 작성](https://github.com/imb96/humming/commit/a0136335acd29d6ddf9d0047c5856f1310f68dfe) 
[feat: user profile 컴포넌트 작성](https://github.com/imb96/humming/commit/1b9067830ee0c4392e63567f128b47ffa69a22e1)
[feat: User type 지정](https://github.com/imb96/humming/commit/9fd7b064db51f0f53eb56572fcc2159e14b90c55)
[feat: userAtom 생성](https://github.com/imb96/humming/commit/41a534cfdbb9dd7e4cdf6437d763fe3cf92611c3)
[feat: 로그인 로직 추가](https://github.com/imb96/humming/commit/5d207c1244b778db5c5bfa54f4496e868f30ceeb) 
[feat: 회원가입 로직 추가](https://github.com/imb96/humming/commit/d4f8f2aab6027f4fecf2b422d40093ff4c7824c2) 
[feat: User Profile Page 생성](https://github.com/imb96/humming/commit/bee6215a045263bfdc9f5ec57ad3763fcc3486f7) 
close #16 